### PR TITLE
♻️ Added error description to networkError state in VM

### DIFF
--- a/Sources/HouseKit/BaseViewModel.swift
+++ b/Sources/HouseKit/BaseViewModel.swift
@@ -12,7 +12,7 @@ import Combine
 
 public enum ViewModelState<T> {
     case loading
-    case networkError
+    case networkError(ServiceError)
     case results(T)
 }
 
@@ -50,7 +50,7 @@ open class BaseViewModel<T>: ObservableObject {
           if case let .failure(error) = result {
             print("Error receiving \(error)")
             DispatchQueue.main.async {
-                self.state = .networkError
+                self.state = .networkError(error)
             }
           }
         }, receiveValue: { value in


### PR DESCRIPTION
This PR adds the `ServiceError` associated object to the `.networkError` case. This will be a breaking change. 💥 
