### PR TITLE
✨ Added a didChangeState method to baseViewModel

### DIFF
--- a/.stampede.yaml
+++ b/.stampede.yaml
@@ -15,6 +15,7 @@ pullrequests:
     - id: swift-package-test
       config:
         projectFolder: .
+        xcodeVersion: Xcode-beta.app
 # tasks that run when a PR is edited
 pullrequestedit:
   tasks:

--- a/Sources/HouseKit/BaseViewModel.swift
+++ b/Sources/HouseKit/BaseViewModel.swift
@@ -23,7 +23,11 @@ open class BaseViewModel<T>: ObservableObject {
 
     // MARK: - Public properties
 
-    @Published public var state: ViewModelState<T> = .loading
+    @Published public var state: ViewModelState<T> = .loading {
+        didSet {
+            self.didChangeState()
+        }
+    }
 
     public var publisher: AnyPublisher<T, ServiceError>? = nil {
         didSet {
@@ -44,6 +48,8 @@ open class BaseViewModel<T>: ObservableObject {
     private var disposables = Set<AnyCancellable>()
 
     // MARK: - Public methods
+    
+    public func didChangeState() { }
 
     public func fetch() {
         self.publisher?.sink(receiveCompletion: { result in


### PR DESCRIPTION
This PR adds a didChangeState method call to the baseViewModel, allowing subclasses the opportunity to do any other work after the state has changed.